### PR TITLE
Implement login cache and JSON-based login

### DIFF
--- a/Auth.gs
+++ b/Auth.gs
@@ -1,11 +1,26 @@
-function verifyLogin(token) {
-  if (!token) return false;
-  // TODO: トークンの有効性を確認する処理を実装する
-  return token === 'valid-token';
+function verifyLogin(id, pw) {
+  if (!id || !pw) return null;
+  var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('送信者');
+  if (!sheet) return null;
+  var data = sheet.getDataRange().getValues();
+  var hash = Utilities.base64Encode(
+    Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, pw, Utilities.Charset.UTF_8)
+  );
+  for (var i = 1; i < data.length; i++) {
+    var row = data[i];
+    if (row[0] === id && row[1] === hash) {
+      var token = Utilities.getUuid();
+      CacheService.getScriptCache().put(token, id, 3600);
+      return token;
+    }
+  }
+  return null;
 }
 
 function getUserFromToken(token) {
-  if (!verifyLogin(token)) return null;
-  // TODO: トークンからユーザー情報を取得する処理を実装する
-  return { id: 'user1', email: 'user@example.com' };
+  if (!token) return null;
+  var cache = CacheService.getScriptCache();
+  var userId = cache.get(token);
+  if (!userId) return null;
+  return { id: userId };
 }

--- a/WebApp.gs
+++ b/WebApp.gs
@@ -3,11 +3,25 @@ function doGet(e) {
 }
 
 function doPost(e) {
-  var token = e.parameter.token;
-  if (!verifyLogin(token)) {
-    return ContentService.createTextOutput('Unauthorized').setMimeType(ContentService.MimeType.TEXT);
+  var data = {};
+  if (e.postData && e.postData.contents) {
+    try {
+      data = JSON.parse(e.postData.contents);
+    } catch (err) {
+      return ContentService.createTextOutput('Invalid JSON').setMimeType(ContentService.MimeType.TEXT);
+    }
   }
-  var user = getUserFromToken(token);
+
+  if (data.action === 'login') {
+    var token = verifyLogin(data.id, data.password);
+    if (!token) {
+      return ContentService.createTextOutput('Unauthorized').setMimeType(ContentService.MimeType.TEXT);
+    }
+    return ContentService.createTextOutput(JSON.stringify({ token: token }))
+      .setMimeType(ContentService.MimeType.JSON);
+  }
+
+  var user = getUserFromToken(data.token);
   if (!user) {
     return ContentService.createTextOutput('Unauthorized').setMimeType(ContentService.MimeType.TEXT);
   }


### PR DESCRIPTION
## Summary
- implement `verifyLogin(id, pw)` using Spreadsheet data and store UUID tokens in ScriptCache
- update `getUserFromToken` to fetch the user from cache
- parse JSON body in `doPost` and handle `action: 'login'`

## Testing
- `echo "no tests"`