### PR TITLE
Implement sheet-driven mail sender with logging

### DIFF
--- a/MailSender.gs
+++ b/MailSender.gs
@@ -1,15 +1,61 @@
-function sendBulkEmails(userId) {
-  if (!userId) return;
-  var recipients = ['recipient1@example.com', 'recipient2@example.com'];
-  var subject = 'Bulk Email';
-  var body = 'Hello from the bulk mailer.';
-  recipients.forEach(function(email) {
-    MailApp.sendEmail(email, subject, body);
-  });
+function sendBulkEmails(senderId) {
+  if (!senderId) return;
+  var ss = SpreadsheetApp.getActiveSpreadsheet();
+  var sendSheet = ss.getSheetByName('送信先');
+  if (!sendSheet) return;
+
+  var values = sendSheet.getDataRange().getValues();
+  var logSheet = ss.getSheetByName('ログ');
+  if (!logSheet) logSheet = ss.insertSheet('ログ');
+  if (logSheet.getLastRow() === 0) {
+    logSheet.appendRow(['日時', '送信者', '宛先', '件名', '本文']);
+  }
+
+  for (var i = 1; i < values.length; i++) {
+    var row = values[i];
+    var recipient = row[0];
+    var subject = row[1];
+    var body = row[2];
+    if (!recipient) continue;
+    MailApp.sendEmail(recipient, subject, body);
+    logSheet.appendRow([new Date(), senderId, recipient, subject, body]);
+  }
+
+  updateSendCount(senderId);
 }
 
-function sendBulkEmailsUI() {
-  var user = getUserFromToken('valid-token');
+function updateSendCount(senderId) {
+  var ss = SpreadsheetApp.getActiveSpreadsheet();
+  var logSheet = ss.getSheetByName('ログ');
+  if (!logSheet) return;
+  var countSheet = ss.getSheetByName('件数');
+  if (!countSheet) countSheet = ss.insertSheet('件数');
+
+  var logs = logSheet.getDataRange().getValues();
+  var count = 0;
+  for (var i = 1; i < logs.length; i++) {
+    if (logs[i][1] === senderId) count++;
+  }
+
+  var summary = countSheet.getDataRange().getValues();
+  var updated = false;
+  for (var i = 1; i < summary.length; i++) {
+    if (summary[i][0] === senderId) {
+      countSheet.getRange(i + 1, 2).setValue(count);
+      updated = true;
+      break;
+    }
+  }
+  if (!updated) {
+    if (summary.length === 0) {
+      countSheet.appendRow(['ユーザーID', '件数']);
+    }
+    countSheet.appendRow([senderId, count]);
+  }
+}
+
+function sendBulkEmailsUI(token) {
+  var user = getUserFromToken(token);
   if (!user) return 'Unauthorized';
   sendBulkEmails(user.id);
   return 'Emails sent';

--- a/index_js.html
+++ b/index_js.html
@@ -4,9 +4,10 @@ document.addEventListener('DOMContentLoaded', function() {
   const button = document.createElement('button');
   button.textContent = 'Send Emails';
   button.addEventListener('click', function() {
+    const token = 'valid-token'; // TODO: 実際のトークン取得処理に置き換える
     google.script.run.withSuccessHandler(function(msg) {
       alert(msg);
-    }).sendBulkEmailsUI();
+    }).sendBulkEmailsUI(token);
   });
   app.appendChild(button);
 });


### PR DESCRIPTION
## Summary
- pull mail data from the `送信先` sheet
- log sent mails in `ログ` and aggregate counts in `件数`
- obtain user ID from token when triggering mail sending
- pass token from front-end

## Testing
- `npm test` *(fails: package.json missing)*