### PR TITLE
Add types packages

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -16,6 +16,9 @@
     "googleapis": "^130.0.0"
   },
   "devDependencies": {
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.0",
+    "@types/node": "*",
+    "@types/firebase-functions": "*",
+    "@types/google-auth-library": "*"
   }
 }


### PR DESCRIPTION
## Summary
- add Node and Firebase function type packages to Cloud Functions

## Testing
- `npm run build` *(fails: could not find declaration files)*
- `npm test` *(fails: tsc errors, tests still run)*
- `npm install` *(fails due to missing network access)*