### PR TITLE
fix admin initialization

### DIFF
--- a/functions/src/admin.ts
+++ b/functions/src/admin.ts
@@ -1,10 +1,11 @@
 import * as firebaseAdmin from 'firebase-admin';
 
 /** Firebase Admin singleton (Node 20 + ESM) */
-const admin = firebaseAdmin as unknown as typeof firebaseAdmin;
+const admin = (firebaseAdmin as any).default ?? firebaseAdmin;
 
 if (!admin.apps.length) {
   admin.initializeApp();
 }
 
 export default admin;
+

--- a/functions/src/sendMail.ts
+++ b/functions/src/sendMail.ts
@@ -1,8 +1,6 @@
 import * as functions from 'firebase-functions';
 import { OAuth2Client } from 'google-auth-library';
-import * as admin from 'firebase-admin';
-
-admin.initializeApp();
+import admin from './admin';
 
 const client = new OAuth2Client();
 


### PR DESCRIPTION
## Summary
- make admin import compatible with CJS/ESM
- use the admin singleton helper in sendMail

## Testing
- `npm test` *(fails: Could not find a declaration file for module 'firebase-admin')*