### PR TITLE
Fix functions build dependencies

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@google-cloud/functions-framework": "^4.0.0",
     "@google-cloud/tasks": "^6.1.0",
-    "firebase-admin": "^13.4.0",
+    "firebase-admin": "^12.7.0",
     "firebase-functions": "^4.4.1",
     "googleapis": "^130.0.0",
     "nodemailer": "^6.9.11"

--- a/functions/src/shims.d.ts
+++ b/functions/src/shims.d.ts
@@ -33,9 +33,9 @@ declare module '@google-cloud/tasks' {
 }
 
 declare module 'google-auth-library' {
-  export class OAuth2Client {
-    verifyIdToken(options: any): Promise<{ getPayload(): any }>;
+export class OAuth2Client {
+      verifyIdToken(options: any): Promise<{ getPayload(): any }>;
+    }
   }
-}
 
 declare const process: any;

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -10,7 +10,8 @@
     "allowSyntheticDefaultImports": true,
     "allowJs": true,
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "skipLibCheck": true
   },
   "include": ["src/**/*.ts", "src/**/*.js"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
## Summary
- downgrade `firebase-admin` to align with `firebase-functions` peer deps
- allow TypeScript build to proceed even without Node types
- skip library checks in TS config

## Testing
- `npm run build` in `functions`
- `npm test`