### PR TITLE
Add env example and update Firebase config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ GCP 上でメール送信を行うサンプルです。Cloud Functions が API �
 
 ## 利用手順
 1. このリポジトリをクローンします。
-2. ルートの `.env.example` をコピーして `.env` を作成し、各値を設定します。
+2. ルートの `.env.example` と `frontend/.env.example` をコピーし、それぞれ `.env` を作成して値を設定します。
    ```bash
    cp .env.example .env
-   # エディタで .env を編集
+   cp frontend/.env.example frontend/.env
+   # エディタで .env と frontend/.env を編集
    ```
 3. 必要に応じて `npm install` を実行します（現状依存パッケージはありません）。
 4. `npm test` を実行しテストが成功することを確認します。

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,8 @@
+# Firebase の API キー
+REACT_APP_FIREBASE_API_KEY=
+
+# Firebase の Auth ドメイン
+REACT_APP_FIREBASE_AUTH_DOMAIN=
+
+# Firebase プロジェクト ID
+REACT_APP_FIREBASE_PROJECT_ID=

--- a/frontend/src/firebase.ts
+++ b/frontend/src/firebase.ts
@@ -2,10 +2,11 @@ import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 
+// 環境変数から Firebase 設定を取得
 const firebaseConfig = {
-  apiKey: 'YOUR_API_KEY',
-  authDomain: 'YOUR_AUTH_DOMAIN',
-  projectId: 'YOUR_PROJECT_ID',
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
+  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
 };
 
 export const app = initializeApp(firebaseConfig);


### PR DESCRIPTION
## Summary
- add `.env.example` for the frontend
- load Firebase config from environment variables
- document how to set up `.env` files

## Testing
- `npm test` *(fails: Cannot find package 'firebase-admin')*