### PR TITLE
Add Cloud Build steps for all functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ npm run build
    gcloud functions deploy getCount --runtime nodejs18 --trigger-http --allow-unauthenticated
    ```
 4. 発行されたエンドポイント URL をフロントエンド設定に入力して利用します。
+5. Cloud Build で全関数をデプロイする場合は次のコマンドを実行します。
+   ```bash
+   gcloud builds submit --config cloudbuild.yaml
+   ```
 
 ## Cloud Tasks と Cloud Scheduler の設定
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,5 +24,46 @@ steps:
       - --entry-point=sheetPuller
       - --trigger-http
       - --allow-unauthenticated
-      - --set-env-vars=SHEET_ID=1mU0OJXnBUj6SlRCPSdWygeOkv1zBUj0GMM-EDS9SHxY,SEND_MAIL_URL=https://asia-northeast1-mail-sender-460609.cloudfunctions.net/sendMail
+      - --set-env-vars=SHEET_ID=1mU0OJXnBUj6SlRCPSdWygeOkv1zBUj0GMM-EDS9SHxY,SEND_MAIL_URL=https://asia-northeast1-mail-sender-460609.cloudfunctions.net/sendMail,QUEUE_NAME=mail-queue,TASKS_REGION=asia-northeast1,TASKS_SERVICE_ACCOUNT=tasks-invoker@mail-sender-460609.iam.gserviceaccount.com
+
+  - name: 'gcr.io/cloud-builders/gcloud'
+    args:
+      - functions
+      - deploy
+      - sendMail
+      - --gen2
+      - --runtime=nodejs20
+      - --region=asia-northeast1
+      - --source=functions
+      - --entry-point=sendMail
+      - --trigger-http
+      - --allow-unauthenticated
+      - --set-env-vars=TASKS_AUDIENCE=https://asia-northeast1-mail-sender-460609.cloudfunctions.net/sendMail,TASKS_SERVICE_ACCOUNT=tasks-invoker@mail-sender-460609.iam.gserviceaccount.com
+
+  - name: 'gcr.io/cloud-builders/gcloud'
+    args:
+      - functions
+      - deploy
+      - login
+      - --gen2
+      - --runtime=nodejs20
+      - --region=asia-northeast1
+      - --source=functions
+      - --entry-point=login
+      - --trigger-http
+      - --allow-unauthenticated
+      - --set-env-vars=FIREBASE_API_KEY=AIzaSyCAqb19fkZxRu40rGOpJp5wHGvLAjSzOdM
+
+  - name: 'gcr.io/cloud-builders/gcloud'
+    args:
+      - functions
+      - deploy
+      - getCount
+      - --gen2
+      - --runtime=nodejs20
+      - --region=asia-northeast1
+      - --source=functions
+      - --entry-point=getCount
+      - --trigger-http
+      - --allow-unauthenticated
 


### PR DESCRIPTION
## Summary
- deploy `sendMail`, `login`, and `getCount` from Cloud Build
- set required environment variables for each function
- document Cloud Build deployment in README

## Testing
- `npm test`