### PR TITLE
Use Cloud Build substitutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,12 @@ npm run build
    ```
 4. 発行されたエンドポイント URL をフロントエンド設定に入力して利用します。
 
-5. Cloud Build で全関数をデプロイする場合は次のコマンドを実行します。
+5. Cloud Build で全関数をデプロイする場合は、`cloudbuild.yaml` に定義された Substitution 変数を指定してビルドを実行します。
    ```bash
-   gcloud builds submit --config cloudbuild.yaml
+   gcloud builds submit --config cloudbuild.yaml \
+     --substitutions=_SHEET_ID=<SHEET_ID>,_SEND_MAIL_URL=<SEND_MAIL_URL>,_QUEUE_NAME=<QUEUE_NAME>,_TASKS_REGION=<TASKS_REGION>,_TASKS_SERVICE_ACCOUNT=<TASKS_SA>,_TASKS_AUDIENCE=<TASKS_AUDIENCE>,_FIREBASE_API_KEY=<API_KEY>
    ```
+   Secret Manager を利用する場合は、`--substitutions` の代わりに `--set-secrets` を用いて環境変数を設定してください。
 
 ## Cloud Tasks と Cloud Scheduler の設定
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,3 +1,12 @@
+substitutions:
+  _SHEET_ID: ''
+  _SEND_MAIL_URL: ''
+  _QUEUE_NAME: ''
+  _TASKS_REGION: ''
+  _TASKS_SERVICE_ACCOUNT: ''
+  _TASKS_AUDIENCE: ''
+  _FIREBASE_API_KEY: ''
+
 steps:
   # 依存関係をインストール
   - name: 'node:20'
@@ -24,7 +33,7 @@ steps:
       - --entry-point=sheetPuller
       - --trigger-http
       - --allow-unauthenticated
-      - --set-env-vars=SHEET_ID=1mU0OJXnBUj6SlRCPSdWygeOkv1zBUj0GMM-EDS9SHxY,SEND_MAIL_URL=https://asia-northeast1-mail-sender-460609.cloudfunctions.net/sendMail,QUEUE_NAME=mail-queue,TASKS_REGION=asia-northeast1,TASKS_SERVICE_ACCOUNT=tasks-invoker@mail-sender-460609.iam.gserviceaccount.com
+      - --set-env-vars=SHEET_ID=$_SHEET_ID,SEND_MAIL_URL=$_SEND_MAIL_URL,QUEUE_NAME=$_QUEUE_NAME,TASKS_REGION=$_TASKS_REGION,TASKS_SERVICE_ACCOUNT=$_TASKS_SERVICE_ACCOUNT
 
   - name: 'gcr.io/cloud-builders/gcloud'
     args:
@@ -38,7 +47,7 @@ steps:
       - --entry-point=sendMail
       - --trigger-http
       - --allow-unauthenticated
-      - --set-env-vars=TASKS_AUDIENCE=https://asia-northeast1-mail-sender-460609.cloudfunctions.net/sendMail,TASKS_SERVICE_ACCOUNT=tasks-invoker@mail-sender-460609.iam.gserviceaccount.com
+      - --set-env-vars=TASKS_AUDIENCE=$_TASKS_AUDIENCE,TASKS_SERVICE_ACCOUNT=$_TASKS_SERVICE_ACCOUNT
 
   - name: 'gcr.io/cloud-builders/gcloud'
     args:
@@ -52,7 +61,7 @@ steps:
       - --entry-point=login
       - --trigger-http
       - --allow-unauthenticated
-      - --set-env-vars=FIREBASE_API_KEY=AIzaSyCAqb19fkZxRu40rGOpJp5wHGvLAjSzOdM
+      - --set-env-vars=FIREBASE_API_KEY=$_FIREBASE_API_KEY
 
   - name: 'gcr.io/cloud-builders/gcloud'
     args:


### PR DESCRIPTION
## Summary
- remove hard-coded env values from cloudbuild.yaml
- add substitutions section for deployment variables
- document how to pass these variables to Cloud Build

## Testing
- `npm test`