### PR TITLE
Fix Firestore init

### DIFF
--- a/functions/src/admin.ts
+++ b/functions/src/admin.ts
@@ -12,7 +12,8 @@ if (process.env.USE_ADMIN_STUB) {
 const admin = firebaseAdmin.default ?? firebaseAdmin;
 
 if (!admin.apps.length) {
-  admin.initializeApp();
+  const projectId = process.env.GCP_PROJECT || process.env.PROJECT_ID;
+  admin.initializeApp(projectId ? { projectId } : undefined);
 }
 
 export default admin;


### PR DESCRIPTION
## Summary
- pass projectId from env vars when initializing Firebase Admin

## Testing
- `npm test` *(fails: Cannot find package 'firebase-functions')*