### PR TITLE
Handle Firestore error in DataList

### DIFF
--- a/frontend/src/pages/DataList.tsx
+++ b/frontend/src/pages/DataList.tsx
@@ -14,17 +14,25 @@ interface MailRow {
 
 const DataList: React.FC = () => {
   const [rows, setRows] = useState<MailRow[]>([]);
+  const [error, setError] = useState<string | null>(null); // エラー表示用
 
   useEffect(() => {
+    // Firestore からデータ取得
     (async () => {
-      const snap = await getDocs(collection(db, 'mailData'));
-      setRows(snap.docs.map(d => d.data() as MailRow));
+      try {
+        const snap = await getDocs(collection(db, 'mailData'));
+        setRows(snap.docs.map(d => d.data() as MailRow));
+      } catch (err) {
+        console.error(err);
+        setError('Error loading data');
+      }
     })();
   }, []);
 
   return (
     <div style={{ padding: 24 }}>
       <h2>\u53d6\u308a\u8fbc\u307f\u6e08\u307f\u30c7\u30fc\u30bf\u4e00\u89a7\uff08{rows.length} \u4ef6\uff09</h2>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
       <table border={1} cellPadding={4} style={{ borderCollapse: 'collapse' }}>
         <thead>
           <tr>


### PR DESCRIPTION
## Summary
- handle Firestore error in `DataList`

## Testing
- `npm test` *(fails: Cannot find module 'firebase-functions')*