### PR TITLE
Use row[3] for Firestore ID

### DIFF
--- a/functions/src/sheetPuller.ts
+++ b/functions/src/sheetPuller.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions';
 import admin from './admin.js';
 import dotenv from 'dotenv';
+import { randomUUID } from 'crypto';
 
 dotenv.config();
 // admin.initializeApp(); ← 削除します
@@ -36,8 +37,7 @@ export const sheetPuller = functions.https.onRequest(async (_req: any, res: any)
     const batch = db.batch();
 
     values.slice(1).forEach((row: string[]) => {
-      const id = row[0];
-      if (!id) return;
+      const id = row[3] || randomUUID();
       const docRef = db.collection('mailData').doc(id);
       batch.set(docRef, {
         send_date: row[0] || '',

--- a/test.js
+++ b/test.js
@@ -65,7 +65,7 @@ const res4 = { statusCode: 200, body: null, json(d){this.body=d;}, status(c){thi
 await sheetPuller({}, res4);
 assert.strictEqual(res4.statusCode, 200);
 assert.deepStrictEqual(res4.body, { pulled: 2 });
-assert.deepStrictEqual(admin.__getData('mailData/1'), {
+assert.deepStrictEqual(admin.__getData('mailData/d1'), {
   send_date: '1',
   progress: 'b1',
   manager_name: 'c1',
@@ -74,7 +74,7 @@ assert.deepStrictEqual(admin.__getData('mailData/1'), {
   operator_name: 'f1',
   email: 'g1'
 });
-assert.deepStrictEqual(admin.__getData('mailData/2'), {
+assert.deepStrictEqual(admin.__getData('mailData/d2'), {
   send_date: '2',
   progress: 'b2',
   manager_name: 'c2',


### PR DESCRIPTION
## Summary
- reference row[3] or a generated UUID when creating mailData document IDs
- adjust tests to reflect new ID field

## Testing
- `npm test` *(fails: Cannot find package 'firebase-functions')*