### PR TITLE
Add mail sending UI and SMTP support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,13 @@ PROJECT_ID=<YOUR_PROJECT_ID>
 
 # デプロイ環境では自動設定される GCP プロジェクト ID
 GCP_PROJECT=<YOUR_GCP_PROJECT>
+
+# SMTP サーバ設定
+SMTP_HOST=smtp.example.com
+SMTP_PORT=465
+SMTP_USER=your_username
+SMTP_PASS=your_password
+SMTP_FROM=your@example.com
+
+# フォローアップ間隔(日)
+FOLLOWUP_INTERVAL_DAYS=7

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -10,3 +10,6 @@ REACT_APP_FIREBASE_PROJECT_ID=
 # Cloud Functions のベースURL
 REACT_APP_FUNCTIONS_BASE_URL=
 
+# フォローアップ設定ドキュメントパス
+REACT_APP_FOLLOWUP_DOC=settings/followup
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,8 @@ import Signup from './pages/Signup';
 import Review from './pages/Review';
 import Stats from './pages/Stats';
 import DataList from './pages/DataList';
+import SendMail from './pages/SendMail';
+import Settings from './pages/Settings';
 
 const App: React.FC = () => (
   <div>
@@ -11,7 +13,8 @@ const App: React.FC = () => (
       <Link to="/signup">Signup</Link> |{' '}
       <Link to="/review">Review</Link> |{' '}
       <Link to="/stats">Stats</Link> |{' '}
-      <Link to="/data">Data</Link>
+      <Link to="/data">Data</Link> |{' '}
+      <Link to="/settings">Settings</Link>
     </nav>
     <Routes>
       <Route path="/" element={<Navigate to="/signup" replace />} />
@@ -19,6 +22,8 @@ const App: React.FC = () => (
       <Route path="/review" element={<Review />} />
       <Route path="/stats" element={<Stats />} />
       <Route path="/data" element={<DataList />} />
+      <Route path="/send" element={<SendMail />} />
+      <Route path="/settings" element={<Settings />} />
     </Routes>
   </div>
 );

--- a/frontend/src/pages/SendMail.tsx
+++ b/frontend/src/pages/SendMail.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { db } from '../firebase';
+
+interface State {
+  row?: any;
+}
+
+const SendMail: React.FC = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const state = location.state as State || {};
+  const row = state.row || {};
+
+  const [to, setTo] = useState(row.email || '');
+  const [subject, setSubject] = useState('');
+  const [body, setBody] = useState('');
+  const [checked, setChecked] = useState(false);
+  const [error, setError] = useState('');
+
+  const baseUrl = process.env.REACT_APP_FUNCTIONS_BASE_URL || '';
+
+  const handleSend = async () => {
+    if (!to.match(/^[^@]+@[^@]+$/)) {
+      setError('メールアドレスが不正です');
+      return;
+    }
+    if (!subject || !body) {
+      setError('件名と本文を入力してください');
+      return;
+    }
+
+    const token = localStorage.getItem('token');
+    const resp = await fetch(`${baseUrl}/sendMail`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ id: row.number, to, subject, text: body }),
+    });
+    if (resp.ok) {
+      alert('送信しました');
+      navigate(-1);
+    } else {
+      const data = await resp.json().catch(() => ({}));
+      alert('送信失敗: ' + (data.error || resp.statusText));
+    }
+  };
+
+  return (
+    <div style={{ padding: 24 }}>
+      <h2>メール送信</h2>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <div>
+        <label>宛先:</label>
+        <input value={to} onChange={e => setTo(e.target.value)} />
+      </div>
+      <div>
+        <label>件名:</label>
+        <input value={subject} onChange={e => setSubject(e.target.value)} />
+      </div>
+      <div>
+        <label>本文:</label>
+        <textarea value={body} onChange={e => setBody(e.target.value)} />
+      </div>
+      <div>
+        <h3>プレビュー</h3>
+        <pre>{body}</pre>
+      </div>
+      <div>
+        <label>
+          <input type="checkbox" checked={checked} onChange={e => setChecked(e.target.checked)} /> 確認しました
+        </label>
+      </div>
+      <button onClick={handleSend} disabled={!checked}>送信</button>
+    </div>
+  );
+};
+
+export default SendMail;

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+
+const docPath = process.env.REACT_APP_FOLLOWUP_DOC || 'settings/followup';
+
+const Settings: React.FC = () => {
+  const [days, setDays] = useState('7');
+
+  useEffect(() => {
+    (async () => {
+      const snap = await getDoc(doc(db, docPath));
+      if (snap.exists()) {
+        setDays(String((snap.data() as any).intervalDays || '7'));
+      }
+    })();
+  }, []);
+
+  const save = async () => {
+    await setDoc(doc(db, docPath), { intervalDays: Number(days) });
+    alert('保存しました');
+  };
+
+  return (
+    <div style={{ padding: 24 }}>
+      <h2>フォローアップ設定</h2>
+      <div>
+        <label>間隔(日):</label>
+        <input value={days} onChange={e => setDays(e.target.value)} />
+        <button onClick={save}>保存</button>
+      </div>
+    </div>
+  );
+};
+
+export default Settings;


### PR DESCRIPTION
## Summary
- provide SMTP settings in `.env.example`
- update frontend with SendMail and Settings pages
- add action buttons in data list and copy-assist panel
- implement SMTP mail send logic in Cloud Function
- extend tests for new mail send behavior

## Testing
- `npm test` *(fails: Cannot find module 'firebase-functions')*