### PR TITLE
Add template sheet support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,15 @@ SHEET_RANGE=A:G
 # スプレッドシートの列とFirestoreフィールドの対応
 SHEET_FIELD_MAP={"id":0,"send_date":0,"progress":1,"manager_name":2,"number":3,"facility_name":4,"operator_name":5,"email":6}
 
+# テンプレート取得用スプレッドシートの ID
+TEMPLATE_SHEET_ID=<YOUR_TEMPLATE_SHEET_ID>
+# テンプレートを置いたシート名
+TEMPLATE_SHEET_NAME=Template
+# テンプレート取得範囲
+TEMPLATE_SHEET_RANGE=A:B
+# 件名や本文を取得する列番号の対応
+TEMPLATE_FIELD_MAP={"subject1":0,"body1":1}
+
 # Cloud Tasks ID トークンの audience
 TASKS_AUDIENCE=<YOUR_TASKS_AUDIENCE>
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ GCP 上でメール送信を行うサンプルです。Cloud Functions が API �
    SHEET_NAME=対象シート名（例: 一覧・操作）
    SHEET_RANGE=取得する範囲（例: A:G）
    SHEET_FIELD_MAP={"id":0,"send_date":0,"progress":1,"manager_name":2,"number":3,"facility_name":4,"operator_name":5,"email":6}
+   TEMPLATE_SHEET_ID=テンプレート用スプレッドシートのID
+   TEMPLATE_SHEET_NAME=テンプレートシート名
+   TEMPLATE_SHEET_RANGE=テンプレート取得範囲（例: A:B）
+   TEMPLATE_FIELD_MAP={"subject1":0,"body1":1}
    FIREBASE_API_KEY=FirebaseのAPIキー
    TASKS_AUDIENCE=Cloud Tasksの認証先URL（sendMail関数のURL）
    TASKS_SERVICE_ACCOUNT=Cloud Tasksが使用するサービスアカウント

--- a/frontend/src/pages/DataList.tsx
+++ b/frontend/src/pages/DataList.tsx
@@ -29,6 +29,7 @@ const DataList: React.FC = () => {
   const [lastSentAt, setLastSentAt] = useState<Date | null>(null);
   const [stageLimit, setStageLimit] = useState<number | null>(null);
   const [count, setCount] = useState(0);
+  const [templates, setTemplates] = useState<Record<string, string>>({});
 
   // Firestore から読み込む
   const fetchRows = async () => {
@@ -86,6 +87,11 @@ const DataList: React.FC = () => {
           setLastSentAt(ts);
         }
         if (typeof data.stageLimit === 'number') setStageLimit(data.stageLimit);
+        const t: Record<string, string> = {};
+        ['subject1','body1','subject2','body2'].forEach(k => {
+          if (typeof data[k] === 'string') t[k] = data[k];
+        });
+        setTemplates(t);
       }
     })();
     const ref = doc(db, 'counters', 'default');
@@ -142,11 +148,11 @@ const DataList: React.FC = () => {
           <h3>コピー支援</h3>
           <div>
             <span>件名: </span>
-            <button onClick={() => navigator.clipboard.writeText('お問い合わせ')}>Copy</button>
+            <button onClick={() => navigator.clipboard.writeText(templates.subject1 || '')}>Copy</button>
           </div>
           <div>
             <span>本文: </span>
-            <button onClick={() => navigator.clipboard.writeText('ご担当者様へ')}>Copy</button>
+            <button onClick={() => navigator.clipboard.writeText(templates.body1 || '')}>Copy</button>
           </div>
           <button onClick={markSent}>送信済み</button>
           <button onClick={() => setAssistRow(null)}>閉じる</button>

--- a/frontend/src/pages/SendMail.tsx
+++ b/frontend/src/pages/SendMail.tsx
@@ -37,6 +37,8 @@ const SendMail: React.FC = () => {
           setLastSentAt(ts);
         }
         if (typeof data.stageLimit === 'number') setStageLimit(data.stageLimit);
+        if (!subject && typeof data.subject1 === 'string') setSubject(data.subject1);
+        if (!body && typeof data.body1 === 'string') setBody(data.body1);
       }
     })();
     const ref = doc(db, 'counters', 'default');

--- a/functions/src/googleapis-stub.ts
+++ b/functions/src/googleapis-stub.ts
@@ -1,6 +1,9 @@
-let values: string[][] = [];
+let queue: string[][][] = [];
 export function __setValues(v: string[][]) {
-  values = v;
+  queue = [v];
+}
+export function __setValuesList(v: string[][][]) {
+  queue = v.slice();
 }
 export const google = {
   sheets() {
@@ -8,7 +11,8 @@ export const google = {
       spreadsheets: {
         values: {
           async get() {
-            return { data: { values } };
+            const v = queue.length ? queue.shift() : [];
+            return { data: { values: v } };
           }
         }
       }

--- a/test.js
+++ b/test.js
@@ -64,10 +64,15 @@ assert.strictEqual(res3.body, 'Unauthorized');
 // Test sheetPuller with stubbed Sheets data
 const { sheetPuller } = await import('./functions/dist/sheetPuller.js');
 const sheetsStub = await import('./functions/dist/googleapis-stub.js');
-sheetsStub.__setValues([
-  ['header'],
-  ['1', 'b1', 'c1', 'd1', 'e1', 'f1', 'g1'],
-  ['2', 'b2', 'c2', 'd2', 'e2', 'f2', 'g2']
+sheetsStub.__setValuesList([
+  [
+    ['header'],
+    ['1', 'b1', 'c1', 'd1', 'e1', 'f1', 'g1'],
+    ['2', 'b2', 'c2', 'd2', 'e2', 'f2', 'g2']
+  ],
+  [
+    ['s1', 't1']
+  ]
 ]);
 process.env.SHEET_ID = 'dummy';
 process.env.SHEET_NAME = 'Sheet1';
@@ -83,6 +88,10 @@ process.env.SHEET_FIELD_MAP = JSON.stringify({
   operator_name: 5,
   email: 6
 });
+process.env.TEMPLATE_SHEET_ID = 'tmpl';
+process.env.TEMPLATE_SHEET_NAME = 'T';
+process.env.TEMPLATE_SHEET_RANGE = 'A:B';
+process.env.TEMPLATE_FIELD_MAP = JSON.stringify({ subject1: 0, body1: 1 });
 const res4 = { statusCode: 200, body: null, json(d){this.body=d;}, status(c){this.statusCode=c; return this;} };
 await sheetPuller({}, res4);
 assert.strictEqual(res4.statusCode, 200);
@@ -107,5 +116,6 @@ assert.deepStrictEqual(admin.__getData('mailData/d2'), {
   hp_url: '',
   email: 'g2'
 });
+assert.deepStrictEqual(admin.__getData('settings/followup'), { subject1: 's1', body1: 't1' });
 
 console.log('Tests passed');


### PR DESCRIPTION
## Summary
- add new environment variables for template sheets
- document template sheet variables in README
- support reading email templates in sheetPuller
- use templates in DataList and SendMail pages
- enhance Sheets API stub for multiple calls
- extend tests for template sheet handling

## Testing
- `npm test` *(fails: Cannot find module 'firebase-functions')*