### PR TITLE
Fix env docs and ignore patterns

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,8 @@ SMTP_PORT=465
 SMTP_USER=your_username
 SMTP_PASS=your_password
 SMTP_FROM=your@example.com
+SMTP_SECURE=true
+SMTP_DISABLE=0
 
 # フォローアップ間隔(日)
 FOLLOWUP_INTERVAL_DAYS=7

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,5 @@
-
-# Dependencies
-# root の node_modules を無視
-!node_modules/
-!node_modules/firebase-functions/
-!node_modules/firebase-functions/**
-!node_modules/google-auth-library/
-!node_modules/google-auth-library/**
-!node_modules/nodemailer/
-!node_modules/nodemailer/**
+# Dependency directories
+node_modules/
 functions/node_modules/
 frontend/node_modules/
 
@@ -22,4 +14,3 @@ yarn-error.log*
 
 # Environment files
 .env
-node_modules/

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -10,6 +10,9 @@ REACT_APP_FIREBASE_PROJECT_ID=
 # Cloud Functions のベースURL
 REACT_APP_FUNCTIONS_BASE_URL=
 
+# sheetPuller 関数の URL
+REACT_APP_SHEET_PULLER_URL=
+
 # フォローアップ設定ドキュメントパス
 REACT_APP_FOLLOWUP_DOC=settings/followup
 

--- a/functions/src/shims.d.ts
+++ b/functions/src/shims.d.ts
@@ -38,4 +38,7 @@ export class OAuth2Client {
     }
   }
 
+// nodemailer の型定義が無い場合のスタブ
+declare module 'nodemailer';
+
 declare const process: any;


### PR DESCRIPTION
## Summary
- clean up `.gitignore`
- add missing env vars to examples
- provide nodemailer shim for TypeScript
- remove unused `lib`

## Testing
- `npm run build` *(fails: Cannot find module 'dotenv')*
- `npm test` *(fails: Cannot find package 'firebase-functions')*
