### PR TITLE
表示用テンプレートの追加

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,20 +1,18 @@
 import React, { useEffect, useState } from 'react';
-import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { doc, setDoc } from 'firebase/firestore';
 import { db } from '../firebase';
+import { useFollowupSettings } from '../hooks/useFollowupSettings';
 
 const docPath = process.env.REACT_APP_FOLLOWUP_DOC || 'settings/followup';
 
 const Settings: React.FC = () => {
   const [days, setDays] = useState('7');
+  const { intervalDays, templates } = useFollowupSettings(docPath);
 
+  // intervalDays が取得できたら state を更新
   useEffect(() => {
-    (async () => {
-      const snap = await getDoc(doc(db, docPath));
-      if (snap.exists()) {
-        setDays(String((snap.data() as any).intervalDays || '7'));
-      }
-    })();
-  }, []);
+    if (intervalDays) setDays(String(intervalDays));
+  }, [intervalDays]);
 
   const save = async () => {
     await setDoc(doc(db, docPath), { intervalDays: Number(days) });
@@ -28,6 +26,17 @@ const Settings: React.FC = () => {
         <label>間隔(日):</label>
         <input value={days} onChange={e => setDays(e.target.value)} />
         <button onClick={save}>保存</button>
+      </div>
+      {/* テンプレート確認用 */}
+      <div style={{ marginTop: 24 }}>
+        <h3>Template Preview</h3>
+        <div>
+          <strong>Subject1:</strong> {templates.subject1 || '—'}
+        </div>
+        <div>
+          <strong>Body1:</strong>
+          <pre>{templates.body1 || ''}</pre>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- useFollowupSettings hook を Settings 画面でも利用
- Settings 画面に subject1 / body1 を確認する欄を追加

## Testing
- `npm test` *(失敗: Unauthorized エラー)*